### PR TITLE
Add a check if there are any fields

### DIFF
--- a/src/plugins/system/jtcfshowon/jtcfshowon.php
+++ b/src/plugins/system/jtcfshowon/jtcfshowon.php
@@ -213,11 +213,13 @@ class PlgSystemJtcfshowon extends CMSPlugin
 	 */
 	public function onContentPrepare($context, &$item, &$params, $page = 0)
 	{
+		if (empty($item->jcfields))
+		{
+			return;
+		}
+
 		if (!in_array($context, array('com_users.profile', 'com_users.user')))
 		{
-			if(empty($item->jcfields)) {
-				return;
-			}
 			foreach ($item->jcfields as $key => $cfield)
 			{
 				if (in_array($cfield->name, self::$unshownFields))

--- a/src/plugins/system/jtcfshowon/jtcfshowon.php
+++ b/src/plugins/system/jtcfshowon/jtcfshowon.php
@@ -215,6 +215,9 @@ class PlgSystemJtcfshowon extends CMSPlugin
 	{
 		if (!in_array($context, array('com_users.profile', 'com_users.user')))
 		{
+			if(empty($item->jcfields)) {
+				return;
+			}
 			foreach ($item->jcfields as $key => $cfield)
 			{
 				if (in_array($cfield->name, self::$unshownFields))


### PR DESCRIPTION
PHP 8 was throwing warnings: 
```
PHP Warning:  Undefined property: stdClass::$jcfields in [site redacted]/plugins/system/jtcfshowon/jtcfshowon.php on line 218
PHP Warning:  foreach() argument must be of type array|object, null given in [site redacted]/plugins/system/jtcfshowon/jtcfshowon.php on line 218
```

Could also move the check out of the if function, not sure which would be better. :)