### PR TITLE
Check if the field is set before trying to get rawvalue

### DIFF
--- a/src/plugins/system/jtcfshowon/jtcfshowon.php
+++ b/src/plugins/system/jtcfshowon/jtcfshowon.php
@@ -210,7 +210,11 @@ class PlgSystemJtcfshowon extends CMSPlugin
 
 			list($fieldName, $expectedValue) = explode($separator, $rule);
 
-			$fieldValue      = (array) self::$itemFields[$uniqueItemId][$fieldName]->rawvalue;
+			if(isset(self::$itemFields[$uniqueItemId][$fieldName])) {
+				$fieldValue      = (array) self::$itemFields[$uniqueItemId][$fieldName]->rawvalue;
+			} else {
+				$fieldValue = [];
+			}
 			$valueValidation = (($not === false && in_array($expectedValue, $fieldValue))
 				|| ($not === true && !in_array($expectedValue, $fieldValue)));
 

--- a/src/plugins/system/jtcfshowon/jtcfshowon.php
+++ b/src/plugins/system/jtcfshowon/jtcfshowon.php
@@ -156,7 +156,7 @@ class PlgSystemJtcfshowon extends CMSPlugin
 	 * @param   string  $showOn        The value of the show on attribute.
 	 * @param   string  $uniqueItemId  The unique item id.
 	 *
-	 * @return  bool
+	 * @return  bool  Return true if the field is shown.
 	 *
 	 * @since  1.0.5
 	 */
@@ -175,14 +175,15 @@ class PlgSystemJtcfshowon extends CMSPlugin
 
 		$showOn                = str_replace($regex['search'], $regex['replace'], $showOn);
 		$showOnValidationRules = (array) explode(' ', $showOn);
-		$valuesSum             = count($showOnValidationRules) - 1;
-		$conditionValid        = array();
-		$isShown               = false;
 
 		if (empty($showOnValidationRules))
 		{
-			return false;
+			return true;
 		}
+
+		$valuesSum      = count($showOnValidationRules) - 1;
+		$conditionValid = array();
+		$isShown        = true;
 
 		foreach ($showOnValidationRules as $key => $rule)
 		{
@@ -210,11 +211,12 @@ class PlgSystemJtcfshowon extends CMSPlugin
 
 			list($fieldName, $expectedValue) = explode($separator, $rule);
 
-			if(!isset(self::$itemFields[$uniqueItemId][$fieldName])) {
-				return true;
+			$fieldValue = array();
+
+			if (isset(self::$itemFields[$uniqueItemId][$fieldName]))
+			{
+				$fieldValue = (array) self::$itemFields[$uniqueItemId][$fieldName]->rawvalue;
 			}
-			
-			$fieldValue = (array) self::$itemFields[$uniqueItemId][$fieldName]->rawvalue;
 
 			$valueValidation = (($not === false && in_array($expectedValue, $fieldValue))
 				|| ($not === true && !in_array($expectedValue, $fieldValue)));

--- a/src/plugins/system/jtcfshowon/jtcfshowon.php
+++ b/src/plugins/system/jtcfshowon/jtcfshowon.php
@@ -210,11 +210,10 @@ class PlgSystemJtcfshowon extends CMSPlugin
 
 			list($fieldName, $expectedValue) = explode($separator, $rule);
 
-			if(isset(self::$itemFields[$uniqueItemId][$fieldName])) {
-				$fieldValue      = (array) self::$itemFields[$uniqueItemId][$fieldName]->rawvalue;
-			} else {
-				$fieldValue = [];
+			if(!isset(self::$itemFields[$uniqueItemId][$fieldName])) {
+				return true;
 			}
+
 			$valueValidation = (($not === false && in_array($expectedValue, $fieldValue))
 				|| ($not === true && !in_array($expectedValue, $fieldValue)));
 

--- a/src/plugins/system/jtcfshowon/jtcfshowon.php
+++ b/src/plugins/system/jtcfshowon/jtcfshowon.php
@@ -213,6 +213,8 @@ class PlgSystemJtcfshowon extends CMSPlugin
 			if(!isset(self::$itemFields[$uniqueItemId][$fieldName])) {
 				return true;
 			}
+			
+			$fieldValue = (array) self::$itemFields[$uniqueItemId][$fieldName]->rawvalue;
 
 			$valueValidation = (($not === false && in_array($expectedValue, $fieldValue))
 				|| ($not === true && !in_array($expectedValue, $fieldValue)));


### PR DESCRIPTION
Sometimes validation rules will be set on fields in contexts where the checked field doesn't exist, resulting in a PHP warning:
`[24-Aug-2022 08:48:43 UTC] PHP Warning:  Attempt to read property "rawvalue" on null in /plugins/system/jtcfshowon/jtcfshowon.php on line 213`

 Checking if the field exists first prevents that. Please test this though before merging to make sure it's not causing unexpected behavior of hidden fields again... seems okay in my use case, but not sure if it would affect other things.